### PR TITLE
Add scripts to de-duplicate pedestrian network

### DIFF
--- a/dvrpc_scripts/josm_deduplicate_crosswalks.js
+++ b/dvrpc_scripts/josm_deduplicate_crosswalks.js
@@ -1,0 +1,86 @@
+// Rhino script file for JOSM
+// Looks for DVRPC pedestrian network crosswalks duplicated in the existing OSM street network.
+var util = require("josm/util");
+var console = require("josm/scriptingconsole");
+var layers = require("josm/layers");
+
+console.clear();
+console.println("starting...");
+util.println('starting...');
+
+
+var ds = layers.activeLayer.data;
+var dvrpcCrosswalks = ds.query("highway=footway footway=crossing dvrpc\\:objectid=*");
+var osmCrosswalks = ds.query("highway=footway footway=crossing -dvrpc\\:objectid=*");
+util.println('got crosswalks');
+
+console.println("found " + osmCrosswalks.length + " OSM crosswalks");
+console.println("found " + dvrpcCrosswalks.length + " DVRPC crosswalks");
+
+var foundMatches = 0;
+var multipleMatches = 0;
+
+osmCrosswalks.forEach(function (cw) {
+    var cwFirstCoord = cw.firstNode().getCoor();
+    var cwLastCoord = cw.lastNode().getCoor();
+    console.println('\ncrosswalk: ' + cw.id + ' has ' + cw.nodes.length + ' nodes');
+    var cwLength = cwFirstCoord.greatCircleDistance(cwLastCoord);
+    console.println('crosswalk length: ' + cwLength);
+    cw.nodes.forEach(function(n, idx) {
+        var parentWays = n.getParentWays();
+        var pwIterator = parentWays.iterator();
+        while (pwIterator.hasNext()) {
+            var p = pwIterator.next();
+            var wayName = p.get('name');
+            if (wayName) {
+                console.println('\tnode ' + idx + ' has parent way: ' + wayName);
+            }
+        }
+    });
+
+    var foundDvrpcCrosswalk = null;
+    // skip checking DVRPC crosswalks with an endpoint more than this distance away
+    var maxBoundDistance = cwLength + 10;
+    var maxEndNodeDistance = 5;
+    for (i = 0; i < dvrpcCrosswalks.length; i++) {
+        var dvrpc = dvrpcCrosswalks[i];
+        var firstDvrpcCoord = dvrpc.firstNode().getCoor();
+        var distanceFirstToFirst = firstDvrpcCoord.greatCircleDistance(cwFirstCoord);
+        if (distanceFirstToFirst > maxBoundDistance) {
+            continue;
+        }
+        var distanceFirstToLast = firstDvrpcCoord.greatCircleDistance(cwLastCoord);
+        var firstClosest =  distanceFirstToFirst < distanceFirstToLast;
+        var shortest = firstClosest ? distanceFirstToFirst : distanceFirstToLast;
+        if (shortest > maxEndNodeDistance) {
+            continue;
+        }
+        var lastDvrpcCoord = dvrpc.lastNode().getCoor();
+        var otherDistance = firstClosest ? lastDvrpcCoord.greatCircleDistance(cwLastCoord)
+            : lastDvrpcCoord.greatCircleDistance(cwFirstCoord);
+        if (otherDistance > maxEndNodeDistance) {
+            continue;
+        }
+        if (!foundDvrpcCrosswalk) {
+            foundDvrpcCrosswalk = dvrpc;
+        } else {
+            console.println('Already have matching DVRPC crosswalk! Not using either.');
+            multipleMatches += 1;
+            foundDvrpcCrosswalk = null;
+            break;
+        }
+    }
+
+    if (foundDvrpcCrosswalk) {
+        console.println('Found matching crosswalk for OSM crosswalk. Deleting OSM crosswalk.\n');
+        cw.setDeleted(true);
+        foundMatches += 1;
+    }
+});
+
+console.println("\n\nFound " + foundMatches + " DVRPC crosswalks for the " +
+    osmCrosswalks.length + " OSM crosswalks");
+console.println("Had " + multipleMatches +
+    " OSM crosswalks with more than one seeming DVRPC crosswalk match.");
+util.println("all done!");
+console.println("\nall done");

--- a/dvrpc_scripts/josm_deduplicate_crosswalks.js
+++ b/dvrpc_scripts/josm_deduplicate_crosswalks.js
@@ -73,6 +73,18 @@ osmCrosswalks.forEach(function (cw) {
 
     if (foundDvrpcCrosswalk) {
         console.println('Found matching crosswalk for OSM crosswalk. Deleting OSM crosswalk.\n');
+        // First traverse the way nodes and delete any not connected to anything else
+        // that would be orphaned by deleting this way.
+        // Leave any `highway=crossing` nodes also connected to the street
+        // (but do not connect such nodes to pedestrian-only network.)
+        cw.nodes.forEach(function(n, idx) {
+            var parentWays = n.getParentWays();
+            if (parentWays.size() === 1) {
+                // first remove node from way, to avoid integrity error on attempting to delete way
+                cw.removeNode(n);
+                n.setDeleted(true);
+            }
+        });
         cw.setDeleted(true);
         foundMatches += 1;
     }

--- a/dvrpc_scripts/josm_deduplicate_sidewalks.js
+++ b/dvrpc_scripts/josm_deduplicate_sidewalks.js
@@ -63,6 +63,16 @@ osmSidewalks.forEach(function (sd) {
 
     if (foundDvrpcSidewalk) {
         console.println('Found matching sidewalk for OSM sidewalk. Deleting OSM sidewalk.\n');
+        // First traverse the way nodes and delete any not connected to anything else
+        // that would be orphaned by deleting this way.
+        sd.nodes.forEach(function(n, idx) {
+            var parentWays = n.getParentWays();
+            if (parentWays.size() === 1) {
+                // first remove node from way, to avoid integrity error on attempting to delete way
+                sd.removeNode(n);
+                n.setDeleted(true);
+            }
+        });
         sd.setDeleted(true);
         foundMatches += 1;
     }

--- a/dvrpc_scripts/josm_deduplicate_sidewalks.js
+++ b/dvrpc_scripts/josm_deduplicate_sidewalks.js
@@ -1,0 +1,76 @@
+// Rhino script file for JOSM
+// Looks for DVRPC pedestrian network sidewalks duplicated in the existing OSM street network.
+
+var util = require("josm/util");
+var console = require("josm/scriptingconsole");
+var layers = require("josm/layers");
+
+console.clear();
+console.println("starting...");
+util.println('starting...');
+
+
+var ds = layers.activeLayer.data;
+var dvrpcSidewalks = ds.query("highway=footway footway=sidewalk dvrpc\\:objectid=*");
+var osmSidewalks = ds.query("highway=footway footway=sidewalk -dvrpc\\:objectid=*");
+util.println('got sidewalks');
+
+console.println("found " + osmSidewalks.length + " OSM sidewalks");
+console.println("found " + dvrpcSidewalks.length + " DVRPC sidewalks");
+
+var foundMatches = 0;
+var multipleMatches = 0;
+
+osmSidewalks.forEach(function (sd) {
+    var sdFirstCoord = sd.firstNode().getCoor();
+    var sdLastCoord = sd.lastNode().getCoor();
+    console.println('\nsidewalk: ' + sd.id + ' has ' + sd.nodes.length + ' nodes');
+    var sdLength = sdFirstCoord.greatCircleDistance(sdLastCoord);
+    console.println('sidewalk length: ' + sdLength);
+
+    var foundDvrpcSidewalk = null;
+    // skip checking DVRPC sidewalks with an endpoint more than this distance away
+    var maxBoundDistance = sdLength + 10;
+    var maxEndNodeDistance = 5;
+    for (i = 0; i < dvrpcSidewalks.length; i++) {
+        var dvrpc = dvrpcSidewalks[i];
+        var firstDvrpcCoord = dvrpc.firstNode().getCoor();
+        var distanceFirstToFirst = firstDvrpcCoord.greatCircleDistance(sdFirstCoord);
+        if (distanceFirstToFirst > maxBoundDistance) {
+            continue;
+        }
+        var distanceFirstToLast = firstDvrpcCoord.greatCircleDistance(sdLastCoord);
+        var firstClosest =  distanceFirstToFirst < distanceFirstToLast;
+        var shortest = firstClosest ? distanceFirstToFirst : distanceFirstToLast;
+        if (shortest > maxEndNodeDistance) {
+            continue;
+        }
+        var lastDvrpcCoord = dvrpc.lastNode().getCoor();
+        var otherDistance = firstClosest ? lastDvrpcCoord.greatCircleDistance(sdLastCoord)
+            : lastDvrpcCoord.greatCircleDistance(sdFirstCoord);
+        if (otherDistance > maxEndNodeDistance) {
+            continue;
+        }
+        if (!foundDvrpcSidewalk) {
+            foundDvrpcSidewalk = dvrpc;
+        } else {
+            console.println('Already have matching DVRPC sidewalk! Not using either.');
+            multipleMatches += 1;
+            foundDvrpcSidewalk = null;
+            break;
+        }
+    }
+
+    if (foundDvrpcSidewalk) {
+        console.println('Found matching sidewalk for OSM sidewalk. Deleting OSM sidewalk.\n');
+        sd.setDeleted(true);
+        foundMatches += 1;
+    }
+});
+
+console.println("\n\nFound " + foundMatches + " DVRPC sidewalks for the " +
+    osmSidewalks.length + " OSM sidewalks");
+console.println("Had " + multipleMatches +
+    " OSM sidewalks with more than one seeming DVRPC sidewalk match.");
+util.println("all done!");
+console.println("\nall done");


### PR DESCRIPTION
## Overview

Removes upstream OSM sidewalks and crosswalks that also exist in DVRPC-sourced pedestrian network.

The original task in #7 was only to de-duplicate crosswalks, but in investigating for the task, I found that there were some separate sidewalk ways (linestrings) in the upstream OSM data as well (usually sidewalks are not entered as separate ways, but only noted as properties on the street way.) So I ran similar logic against the sidewalks, and was able to remove some duplicated sidewalks as well.

## Demo

The intersection of Spring Garden and Lawrence street had non-DVRPC as well as DVRPC entries for the Spring Garden sidewalk and crosswalk across Lawrence (non-DVRPC footways selected, in red here):

![josm_n_lawrence_and_spring_garden_before_non_dvrpc_footpaths](https://user-images.githubusercontent.com/960264/79500473-733ab400-7ffa-11ea-9286-692e4530bc1e.png)

After running the scripts, only the (green, named) DVRPC sidewalk and crossing remain:

![josm_n_lawrence_and_spring_garden_after_no_non_dvrpc_footpaths](https://user-images.githubusercontent.com/960264/79500566-99f8ea80-7ffa-11ea-8ea2-1422df85ce17.png)


## Notes

The scripts found and deleted the upstream OSM versions of:
 - 124 DVRPC crosswalks duplicated by upstream OSM crosswalks, out of 235 total upstream OSM crosswalks
 - 74 DVRPC sidewalks duplicated by upstream OSM sidewalks, out of 250 total upstream OSM sidewalks

So, the scripts found about half of the crosswalks and about a third of the sidewalks in the upstream OSM data to duplicate features also in the DVRPC pedestrian network data for the pilot area. From spot checking, it looks like most of the remainder of the upstream features not found in the DVRPC data came from around the periphery, where they are just outside the bounds of the DVRPC pilot area, but inside the bounds of the upstream OSM data fetched to cover the area. For example, there are sidewalk segments from upstream OSM for the north side of Girard and the south side of Vine, which are the northern and southern bounds of the DVRPC dataset, but there are only overlapping DVRPC sidewalk segments for the south side of Girard and north side of Vine.

Most sidewalks have not been entered as separate ways in upstream OSM for our pilot data area, but some have. I considered simply deleting all upstream OSM footpaths, but decided not to, as not all of them duplicate the DVRPC ways or are outside the survey bounds; some of those entered do not overlap with the DVRPC pedestrian ways because they are on private property, such as school campus footpaths, or provide extra detail inside of park areas.

The crosswalk matches are probably more accurate than those for the sidewalks, as they are both found by comparing the start and end points of the segments; if both ends are close to each other, the feature is assumed to be a duplicate by the scripts. Crosswalks are generally short lines with common start and end points, but sidewalks may be broken up into segments of different lengths in the two datasets. In the case of sidewalk segments that have different start and end points, manual editing would be better for resolving duplication in order to also fix other potential differences, such as connecting private property footpaths found in the upstream OSM source to the new DVRPC sidewalks.


## Testing

Visual review only of these research scripts should be fine. There's a significant amount of overlap in logic between the two; if they're going to be used for anything further, they should probably be combined to a single script broken out into functions. However, I think de-duplication of sidewalks would ideally take different approach than simply comparing segment endpoints.

## Bonus testing

Open the named sidewalk OSM file for the pilot area in JOSM. Before running the scripts, you can observe where the OSM vs DVRPC crosswalks and sidewalks are by using the search function to enter the search terms used in the scripts (i.e., `highway=footway footway=sidewalk dvrpc\:objectid=*` will match all the DVRPC sidewalks.)

Run the two scripts above in the Rhino scripting console. The end output should reflect the numbers in the notes above, and the UI should recognize that there are unsaved changes to the file (which are the deleted ways).

To explore the results by examining a particular way by its ID from console output, you can use the search function with a condition like `id:<OSM feature ID>`.


Closes #7 
